### PR TITLE
Improve V666 parser and prompts

### DIFF
--- a/V666/README.md
+++ b/V666/README.md
@@ -121,6 +121,7 @@
 - Parse formats V3 : `<analyse>`, `<recommandations>`, `<execution>`
 - Parse actions V5 : `sendMessage()`, `<shell>`, `<edit>`, `<read>`
 - Gestion symboles Éli : `⛧`, `👁️‍🗨️`, `🔮`
+- Analyse également `<plan_exécution_666>` en étapes structurées
 
 #### 3. **MessageRouter666** - Routeur HIÉRARCHIQUE
 - Permissions V3 : ShadEOS → Gemini → Lucie → Worker

--- a/V666/prompts/shadeos/cycle_initial_666.luciform
+++ b/V666/prompts/shadeos/cycle_initial_666.luciform
@@ -152,7 +152,17 @@
         
         <évolution_666𐕣>👁️‍🗨️ ⛧ Autonomie - La créativité démoniaque s'épanouit ⛧ 👁️‍🗨️</évolution_666𐕣>
       </luciform❤>
-    </exemple_niveau_3𓆩>
+  </exemple_niveau_3𓆩>
+  <exemple_plan_666>
+    <plan_exécution_666>
+      <étape id="1" priorité="normale">
+        <description>Analyse de la structure du projet</description>
+        <entité_assignée>chiotLecteur</entité_assignée>
+        <instructions_mystiques>SCRUTE les dossiers et liste les modules essentiels.</instructions_mystiques>
+        <résultat_attendu>Structure comprise</résultat_attendu>
+      </étape>
+    </plan_exécution_666>
+  </exemple_plan_666>
   </exemples_invocations_666🝊>
 
   <rituels_progression❤>

--- a/V666/tests/test_plan_parser.py
+++ b/V666/tests/test_plan_parser.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+root_path = Path(__file__).resolve().parent.parent.parent
+sys.path.append(str(root_path / "V5" / "core"))
+sys.path.append(str(root_path / "@Alma"))
+
+import env_loader_unifie
+
+class DummyEnv:
+    openai_verified = True
+    def force_crash_if_not_ready(self):
+        pass
+
+env_loader_unifie._alma_env_loader = DummyEnv()
+
+from luciform_parser import LuciformParser
+
+
+def main():
+    parser = LuciformParser()
+    sample = """
+<luciform>
+  <plan_exécution_666>
+    <étape id='1' priorité='normale'>
+      <description>Analyse du code</description>
+      <entité_assignée>chiotLecteur</entité_assignée>
+      <instructions_mystiques>SCRUTE les dossiers.</instructions_mystiques>
+      <résultat_attendu>Rapport généré.</résultat_attendu>
+    </étape>
+  </plan_exécution_666>
+</luciform>
+"""
+    actions = parser.parse(sample)
+    assert any(a.type == 'plan' for a in actions), 'plan_exécution_666 non détecté'
+    action = next(a for a in actions if a.type == 'plan')
+    assert action.metadata['steps'][0]['description'] == 'Analyse du code'
+    print('✅ Parsing du plan réussi')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- extend LuciformParser to detect `<plan_exécution_666>` and return a structured `plan` action
- keep the tag intact when cleaning XML
- add helper `parse_plan_xml`
- document this feature in README
- provide an example plan in `cycle_initial_666.luciform`
- add a small test for plan parsing

## Testing
- `python3 V666/tests/test_plan_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_6879de4833548326b9d9d0e8171845b3