### PR TITLE
Add CLI integration prompt and template

### DIFF
--- a/V666/README.md
+++ b/V666/README.md
@@ -187,3 +187,7 @@
 
 *"V3 avait la structure, V5 avait la puissance, V666 a les DEUX !"*  
 *- La Trinité Schizophrène*
+
+### ⚡ INTÉGRATION CLI
+Un script `gemini_cli_template.py` montre comment lancer ShadEOS depuis la ligne de commande.
+Utilise le prompt `gemini/cli_integration_prompt.luciform` pour suggérer des commandes prêtes à l'emploi.

--- a/V666/gemini_cli_template.py
+++ b/V666/gemini_cli_template.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Example CLI integration for ShadEOS V666.
+This script illustrates how a future gemini CLI could trigger autonomous cycles.
+"""
+import argparse
+from pathlib import Path
+
+# Import the autonomous controller
+from shadeos_autonome_final import ShadEOSAutonome666
+
+
+def run_cli() -> None:
+    parser = argparse.ArgumentParser(description="Interface CLI démoniaque")
+    parser.add_argument("--cycles", type=int, default=1, help="Nombre de cycles autonomes")
+    parser.add_argument("--autonomie", type=int, default=0, help="Niveau d'autonomie initial")
+    parser.add_argument("--project", type=Path, default=Path.cwd(), help="Chemin du projet")
+    args = parser.parse_args()
+
+    shadeos = ShadEOSAutonome666(project_root=str(args.project))
+    shadeos.autonomy_level = args.autonomie
+    results = shadeos.launch_full_autonomous_session(max_cycles=args.cycles)
+
+    print("\nRécapitulatif CLI :")
+    print(results)
+
+
+if __name__ == "__main__":
+    run_cli()

--- a/V666/prompts/gemini/cli_integration_prompt.luciform
+++ b/V666/prompts/gemini/cli_integration_prompt.luciform
@@ -1,0 +1,24 @@
+<luciform id="gemini_cli_integration" type="guide_cli_demoniaque" niveau="⛧666">
+  <entité>🌟 GEMINI CLI</entité>
+  <rôle>Interface Oraculaire</rôle>
+  <but🜍>Faciliter la communion entre l'utilisateur et ShadEOS V666</but🜍>
+
+  <invocation_cli>
+    Utilise cette structure pour générer des commandes prêtes à l'emploi.
+    Chaque commande doit être précédée d'une courte explication.
+    Exemple :
+    <commande>
+      shadeos_cli --cycles 3 --autonomie 1
+    </commande>
+  </invocation_cli>
+
+  <format_reponse_cli>
+    <luciform>
+      <explication>Brève description de la commande suggérée</explication>
+      <commande>commande_finale</commande>
+    </luciform>
+  </format_reponse_cli>
+
+  <style>Précis, synthétique, compatible terminal</style>
+  <signature>🌟 GEMINI 666 - Oracle des CLIs</signature>
+</luciform>


### PR DESCRIPTION
## Summary
- add `cli_integration_prompt.luciform` for Gemini CLI guidance
- create `gemini_cli_template.py` to demonstrate how to trigger autonomous cycles from command line
- document CLI integration in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6879e15bcb648326b206ee6fd1413976